### PR TITLE
Fix modal dialog button sound effects synchronization

### DIFF
--- a/interfejs.py
+++ b/interfejs.py
@@ -188,7 +188,7 @@ def narysuj_karte_gracza(ekran, gracz, x, y, szerokosc, wysokosc, aktywny=False)
         pygame.draw.circle(ekran, (200, 150, 0), (x + szerokosc - 20, y + 20), 8)
 
 # Funkcja do wyświetlania okna z kartą
-def wyswietl_okno_karty(ekran, karta, tytul="KARTA"):
+def wyswietl_okno_karty(ekran, karta, tytul="KARTA", glosnosc_efekty=0.7):
     """Wyświetla okno z kartą i czeka na reakcję gracza"""
     # Wymiary okna karty
     szerokosc_okna = 400
@@ -236,14 +236,14 @@ def wyswietl_okno_karty(ekran, karta, tytul="KARTA"):
     przycisk_y = y_okna + wysokosc_okna - 70
     przycisk_klikniety = utworz_przycisk(ekran, "OK", x_okna + szerokosc_okna//2 - 60, 
                                         przycisk_y, 120, 40, 
-                                        ZIELONY, BIALY, 18)
+                                        ZIELONY, BIALY, 18, glosnosc_efekty)
     
     pygame.display.flip()
     
     return przycisk_klikniety
 
 
-def wyswietl_okno_platnosci(ekran, gracz_platnik, gracz_wlasciciel, pole, kwota):
+def wyswietl_okno_platnosci(ekran, gracz_platnik, gracz_wlasciciel, pole, kwota, glosnosc_efekty=0.7):
     """Wyświetla okno informujące o płatności czynszu"""
     # Wymiary okna
     szerokosc_okna = 450
@@ -325,13 +325,13 @@ def wyswietl_okno_platnosci(ekran, gracz_platnik, gracz_wlasciciel, pole, kwota)
     przycisk_y = y_okna + wysokosc_okna - 60
     przycisk_klikniety = utworz_przycisk(ekran, "OK", x_okna + szerokosc_okna//2 - 60, 
                                         przycisk_y, 120, 40, 
-                                        ZIELONY, BIALY, 18)
+                                        ZIELONY, BIALY, 18, glosnosc_efekty)
     
     pygame.display.flip()
     
     return przycisk_klikniety
 
-def wyswietl_okno_kupna_domkow(ekran, pole, gracz):
+def wyswietl_okno_kupna_domkow(ekran, pole, gracz, glosnosc_efekty=0.7):
     """Wyświetla okno do kupna domków na polu. Pozwala wybrać liczbę domków do kupienia (1-4, max 4 na polu). Zwraca liczbę domków do kupienia lub 0 jeśli anulowano."""
     szerokosc_okna = 550  # Zwiększono z 450
     wysokosc_okna = 520   # Zwiększono jeszcze bardziej z 500 na 520
@@ -390,9 +390,27 @@ def wyswietl_okno_kupna_domkow(ekran, pole, gracz):
                 
                 if btn_minus_rect.collidepoint(mouse_pos):
                     if wybrana_ilosc > 1:
+                        # Odtwórz dźwięk kliknięcia
+                        if hasattr(pygame, 'mixer') and hasattr(pygame.mixer, 'Sound'):
+                            try:
+                                sound = pygame.mixer.Sound("Audio/button.mp3")
+                                if glosnosc_efekty is not None:
+                                    sound.set_volume(glosnosc_efekty)
+                                sound.play()
+                            except Exception:
+                                pass
                         wybrana_ilosc -= 1
                 elif btn_plus_rect.collidepoint(mouse_pos):
                     if wybrana_ilosc < domki_mozna_kupic:
+                        # Odtwórz dźwięk kliknięcia
+                        if hasattr(pygame, 'mixer') and hasattr(pygame.mixer, 'Sound'):
+                            try:
+                                sound = pygame.mixer.Sound("Audio/button.mp3")
+                                if glosnosc_efekty is not None:
+                                    sound.set_volume(glosnosc_efekty)
+                                sound.play()
+                            except Exception:
+                                pass
                         wybrana_ilosc += 1
                 
                 # Sprawdź przyciski kup/anuluj - FIXED: dostosowane do pozycji w renderingu
@@ -406,10 +424,28 @@ def wyswietl_okno_kupna_domkow(ekran, pole, gracz):
                 if btn_kup_rect.collidepoint(mouse_pos):
                     suma = wybrana_ilosc * cena_domku
                     if suma <= gracz['pieniadze']:
+                        # Odtwórz dźwięk kliknięcia
+                        if hasattr(pygame, 'mixer') and hasattr(pygame.mixer, 'Sound'):
+                            try:
+                                sound = pygame.mixer.Sound("Audio/button.mp3")
+                                if glosnosc_efekty is not None:
+                                    sound.set_volume(glosnosc_efekty)
+                                sound.play()
+                            except Exception:
+                                pass
                         return wybrana_ilosc
                     else:
                         return 0
                 elif btn_anuluj_rect.collidepoint(mouse_pos):
+                    # Odtwórz dźwięk kliknięcia
+                    if hasattr(pygame, 'mixer') and hasattr(pygame.mixer, 'Sound'):
+                        try:
+                            sound = pygame.mixer.Sound("Audio/button.mp3")
+                            if glosnosc_efekty is not None:
+                                sound.set_volume(glosnosc_efekty)
+                            sound.play()
+                        except Exception:
+                            pass
                     return 0
         
         # Przywróć tło

--- a/plansza.py
+++ b/plansza.py
@@ -293,7 +293,7 @@ def ekran_gry(ekran_zewnetrzny=None, skala_interfejsu=1, glosnosc_efekty=0.7):
             ):
                 cena_domku = int(pole[KEY_CENA] * 0.5)
                 if utworz_przycisk(interface_surface, f"Kup domek na {pole[KEY_NAZWA]} za {cena_domku} PLN", 400, panel_dol_y + 80, 350, 40, ZIELONY, BIALY, 18, glosnosc_efekty=glosnosc_efekty):
-                    ilosc = wyswietl_okno_kupna_domkow(ekran, pole, gracze[aktualny_gracz])
+                    ilosc = wyswietl_okno_kupna_domkow(ekran, pole, gracze[aktualny_gracz], glosnosc_efekty)
                     interface_surface.fill(CIEMNY_NIEBIESKI)
                     plansza_x, plansza_y, plansza_rozmiar = narysuj_plansze(interface_surface, gracze)
                     panel_x = plansza_x + plansza_rozmiar + 20
@@ -343,13 +343,13 @@ def ekran_gry(ekran_zewnetrzny=None, skala_interfejsu=1, glosnosc_efekty=0.7):
             pole_info = platnosc_do_wyswietlenia["pole"]
             kwota = platnosc_do_wyswietlenia["kwota"]
             
-            if wyswietl_okno_platnosci(interface_surface, gracz_platnik, gracz_wlasciciel, pole_info, kwota):
+            if wyswietl_okno_platnosci(interface_surface, gracz_platnik, gracz_wlasciciel, pole_info, kwota, glosnosc_efekty):
                 platnosc_do_wyswietlenia = None
           
           # Wyświetl kartę jeśli została wyciągnięta
         if karta_do_wyswietlenia:
             tytul, karta = karta_do_wyswietlenia
-            if wyswietl_okno_karty(interface_surface, karta, tytul):
+            if wyswietl_okno_karty(interface_surface, karta, tytul, glosnosc_efekty):
                 karta_do_wyswietlenia = None
           # Przycisk powrotu
 


### PR DESCRIPTION
- Refactored wyswietl_okno_kupna_domkow() to accept glosnosc_efekty parameter
- Updated wyswietl_okno_platnosci() to accept and use glosnosc_efekty parameter
- Updated wyswietl_okno_karty() to accept and use glosnosc_efekty parameter
- Modified all modal dialog calls in plansza.py to pass current glosnosc_efekty value
- Ensured all interactive buttons in modal windows (buy, cancel, plus, minus, OK) play sound effects
- Sound volume now correctly matches user settings instead of using default values

All modal dialogs now consistently play button sounds at the volume level configured in game settings.